### PR TITLE
On pedal press, if in steer error state, do not send ACC cancel button message.

### DIFF
--- a/selfdrive/car/chrysler/interface.py
+++ b/selfdrive/car/chrysler/interface.py
@@ -237,7 +237,7 @@ class CarInterface(object):
     self.send_cancel_acc = False
     if (ret.gasPressed and (not self.gas_pressed_prev) and ret.vEgo > 2.0):
       events.append(create_event('pedalPressed', [ET.NO_ENTRY, ET.USER_DISABLE]))
-      if (ret.cruiseState.enabled):
+      if (ret.cruiseState.enabled and not self.CS.steer_error):
         self.send_cancel_acc = True
 
     if self.low_speed_alert:


### PR DESCRIPTION
On pedal press, if in steer error state, do not send ACC cancel button message.
Sending the ACC cancel button message in this state causes the car to display warnings.
